### PR TITLE
Accepts RUSAGE_THREAD for getrusage

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -92,4 +92,7 @@ have_const('P_PID', 'signal.h') || have_const('P_PID', 'sys/wait.h')
 have_const('P_PROJID', 'signal.h')
 have_const('P_TASKID', 'signal.h')
 
+# RUSAGE_THREAD is Linux-specific
+have_const('RUSAGE_THREAD', 'sys/resource.h')
+
 create_makefile('proc/wait3', 'proc')

--- a/ext/proc/wait3.c
+++ b/ext/proc/wait3.c
@@ -968,7 +968,7 @@ void Init_wait3()
   rb_define_const(rb_mProcess, "P_PROJID", INT2FIX(P_PROJID));
 #endif
 
-#ifdef HAVE_GETRUSAGE
+#ifdef HAVE_CONST_RUSAGE_THREAD
   rb_define_const(rb_mProcess, "RUSAGE_THREAD", INT2FIX(RUSAGE_THREAD));
 #endif
 


### PR DESCRIPTION
Hello,

It can be useful to pass `RUSAGE_THREAD` to `getrusage`, to collect informations about one specific thread.
