### PR TITLE
Use sigaction and other updates

### DIFF
--- a/examples/example_pause.rb
+++ b/examples/example_pause.rb
@@ -11,7 +11,7 @@ require 'proc/wait3'
 
 puts "Pausing.  Hit Ctrl-C to continue."
 
-if RbConfig::CONFIG['host_os'] =~ /linux/i
+if RbConfig::CONFIG['host_os'] =~ /linux|darwin/i
    Process.pause(2)
 else
    Process.pause("INT")

--- a/examples/example_pause.rb
+++ b/examples/example_pause.rb
@@ -11,7 +11,7 @@ require 'proc/wait3'
 
 puts "Pausing.  Hit Ctrl-C to continue."
 
-if Config::CONFIG['host_os'] =~ /linux/i
+if RbConfig::CONFIG['host_os'] =~ /linux/i
    Process.pause(2)
 else
    Process.pause("INT")

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,7 +7,7 @@ require 'mkmf'
 dir_config('proc-wait3')
 
 have_header('wait.h')
-have_header('sys/resource.h')
+have_header('sys/resource.h') # apt install libbsd-dev
 have_header('sys/wait.h')
 
 # wait3 is mandatory.

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -53,20 +53,7 @@ have_struct_member('struct siginfo', 'si_stime', 'signal.h')
 
 have_const('P_CID', 'signal.h')
 have_const('P_GID', 'signal.h')
-have_const('P_MYID', 'signal.hclass PasswdStruct < FFI::Struct
-      layout(
-        :pw_name, :string,
-        :pw_passwd, :string,
-        :pw_uid, :uint,
-        :pw_gid, :uint,
-        :pw_change, :ulong,
-        :pw_class, :string,
-        :pw_gecos, :string,
-        :pw_dir, :string,
-        :pw_shell, :string,
-        :pw_expire, :ulong
-      )
-    end')
+have_const('P_MYID', 'signal.h')
 have_const('P_SID', 'signal.h')
 have_const('P_UID', 'signal.h')
 

--- a/spec/proc_wait3_spec.rb
+++ b/spec/proc_wait3_spec.rb
@@ -9,6 +9,9 @@ require 'rspec'
 require 'rbconfig'
 
 RSpec.describe Process do
+  # Something in the guts of Ruby was being a pain.
+  Signal.trap('CHLD', 'IGNORE') if RUBY_VERSION.to_f < 3
+
   let(:solaris) { RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i }
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /darwin|osx/i }
   let(:hpux)    { RbConfig::CONFIG['host_os'] =~ /hpux/i }

--- a/spec/proc_wait3_spec.rb
+++ b/spec/proc_wait3_spec.rb
@@ -9,8 +9,6 @@ require 'rspec'
 require 'rbconfig'
 
 RSpec.describe Process do
-  Signal.trap('CHLD', 'IGNORE')
-
   let(:solaris) { RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i }
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /darwin|osx/i }
   let(:hpux)    { RbConfig::CONFIG['host_os'] =~ /hpux/i }

--- a/spec/proc_wait3_spec.rb
+++ b/spec/proc_wait3_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Process do
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /darwin|osx/i }
   let(:hpux)    { RbConfig::CONFIG['host_os'] =~ /hpux/i }
   let(:linux)   { RbConfig::CONFIG['host_os'] =~ /linux/i }
-  let(:freebsd) { RbConfig::CONFIG['host_os'] =~ /bsd/i }
+  let(:bsd)     { RbConfig::CONFIG['host_os'] =~ /bsd|dragonfly/i }
 
   let(:proc_stat_members) {
     %i[
@@ -132,20 +132,20 @@ RSpec.describe Process do
   end
 
   example "waitid method is defined" do
-    skip 'waitid test skipped on this platform' if hpux || darwin || freebsd
+    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
 
     expect(Process).to respond_to(:waitid)
   end
 
   example "waitid method works as expected" do
-    skip 'waitid test skipped on this platform' if hpux || darwin || freebsd
+    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
 
     @pid = fork{ sleep 0.5 }
     expect{ Process.waitid(Process::P_PID, @pid, Process::WEXITED) }.not_to raise_error
   end
 
   example "waitid method raises expected errors if wrong argument type is passed" do
-    skip 'waitid test skipped on this platform' if hpux || darwin || freebsd
+    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
 
     @pid = fork{ sleep 0.5 }
     expect{ Process.waitid("foo", @pid, Process::WEXITED) }.to raise_error(TypeError)
@@ -154,7 +154,7 @@ RSpec.describe Process do
   end
 
   example "waitid method raises expected error if invalid argument is passed" do
-    skip 'waitid test skipped on this platform' if hpux || darwin || freebsd
+    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
 
     @pid = fork{ sleep 0.5 }
     expect{ Process.waitid(Process::P_PID, 99999999, Process::WEXITED) }.to raise_error(Errno::ECHILD)
@@ -203,7 +203,7 @@ RSpec.describe Process do
   end
 
   example "expected constants are defined" do
-    skip 'wait constant check skipped on this platform' if darwin || freebsd
+    skip 'wait constant check skipped on this platform' if darwin || bsd
 
     expect(Process::WCONTINUED).not_to be_nil
     expect(Process::WEXITED).not_to be_nil
@@ -215,7 +215,7 @@ RSpec.describe Process do
   end
 
   example "expected process type flag constants are defined" do
-    skip 'process type flag check skipped on this platform' if linux || darwin || freebsd
+    skip 'process type flag check skipped on this platform' if linux || darwin || bsd
 
     expect(Process::P_ALL).not_to be_nil
     expect(Process::P_CID).not_to be_nil


### PR DESCRIPTION
What started as a small PR to adjust the signal handling for specs turned into a small refactor. These include:

* Using `sigaction` instead of `sigset` for the `pause` method, since `sigset` is deprecated.
* RbConfig fix for one of the example programs.
* Fix what looks like a copy/paste bug in the extconf.rb file. How long has that been there?
* Add some initial handling for DragonflyBSD.
* Only use `Signal.trap('CHLD', 'IGNORE')` for Ruby 2.x in the specs.