### PR TITLE
Add P_JAILID constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,38 @@ These methods may fail in conjunction with `fork` with `Errno::EINTR` unless
 you pass the WNOHANG flag, or explicitly ignore the `SIGCHLD` signal. Ruby's
 own `wait` methods appear to essentially be doing that behind the scenes.
 
+Note that on some platforms just setting a `SIGCHLD` handler may not be
+enough to prevent an `Errno::EINTR` from occuring since you can never be sure
+what signal it's going to receive. Since this appears to be coming from the
+guts of the Ruby core code itself IMO, it's somewhat out of my hands, but it's
+not impossible to deal with.
+
+A typical idiom would be to simulate the `TEMP_FAILURE_RETRY` macro that the GNU
+library provides. This macro wraps a given function and retries it so long as
+it doesn't fail, or the only failure is an `EINTR`. I've chosen not to integrate
+this into the code directly (yet), but you can simulate it like so:
+
+```ruby
+require 'English'
+
+begin
+  pid = fork{ sleep 1; exit 2 }
+  Process.wait3
+rescue Errno::EINTR
+  retry
+end
+
+p $CHILD_STATUS
+```
+
+For more information please see:
+
+https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Interrupted-Primitives.html
+
+BSD provides another approach using sigaction handlers + `SA_RESTART`, but it requires knowing
+the signal type in advance. So, unless you want to apply the same handler to *every* type of
+signal, I don't find it especially useful.
+
 ## Integration with Ruby's process.c
 I considered simply providing a patch to the core process.c file, but I
 decided against it for two reasons.  First, I wanted to get something

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,7 +14,7 @@ have_header('sys/wait.h')
 
 # wait3 is mandatory.
 unless have_func('wait3')
-  STDERR.puts 'wait3() function not found'
+  warn 'wait3() function not found'
   exit
 end
 
@@ -69,5 +69,8 @@ have_const('P_TASKID', 'signal.h')
 
 # RUSAGE_THREAD is Linux-specific
 have_const('RUSAGE_THREAD', 'sys/resource.h')
+
+# BSD
+have_const('P_JAILID', 'sys/wait.h')
 
 create_makefile('proc/wait3', 'proc')

--- a/ext/proc/wait3.c
+++ b/ext/proc/wait3.c
@@ -957,12 +957,17 @@ void Init_wait3(void)
   rb_define_const(rb_mProcess, "P_PROJID", INT2FIX(P_PROJID));
 #endif
 
+#ifdef HAVE_CONST_P_JAILID
+  /* Process jail ID */
+  rb_define_const(rb_mProcess, "P_JAILID", INT2FIX(P_JAILID));
+#endif
+
 #ifdef HAVE_CONST_RUSAGE_THREAD
   rb_define_const(rb_mProcess, "RUSAGE_THREAD", INT2FIX(RUSAGE_THREAD));
 #endif
 
-  /* 1.9.0: The version of the proc-wait3 library */
-  rb_define_const(rb_mProcess, "WAIT3_VERSION", rb_str_freeze(rb_str_new2("1.9.1")));
+  /* 1.9.2: The version of the proc-wait3 library */
+  rb_define_const(rb_mProcess, "WAIT3_VERSION", rb_str_freeze(rb_str_new2("1.9.2")));
 
   /* Define this last in our Init_wait3 function */
   rb_define_readonly_variable("$last_status", &v_last_status);

--- a/proc-wait3.gemspec
+++ b/proc-wait3.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'proc-wait3'
-  spec.version    = '1.9.1'
+  spec.version    = '1.9.2'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
     'documentation_uri'     => 'https://github.com/djberg96/proc-wait3/wiki',
     'source_code_uri'       => 'https://github.com/djberg96/proc-wait3',
     'wiki_uri'              => 'https://github.com/djberg96/proc-wait3/wiki',
-    'rubygems_mfa_required' => 'true'
+    'rubygems_mfa_required' => 'true',
+    'github_repo'           => 'https://github.com/djberg96/proc-wait3'
   }
 
   spec.description = <<-EOF

--- a/spec/proc_wait3_spec.rb
+++ b/spec/proc_wait3_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Process do
   end
 
   example 'version constant is set to expected value' do
-    expect(Process::WAIT3_VERSION).to eq('1.9.1')
+    expect(Process::WAIT3_VERSION).to eq('1.9.2')
     expect(Process::WAIT3_VERSION).to be_frozen
   end
 
@@ -237,6 +237,11 @@ RSpec.describe Process do
 
     expect(Process::P_TASKID).not_to be_nil
     expect(Process::P_PROJID).not_to be_nil
+  end
+
+  example 'bsd-specific process type flags are defined on BSD platforms' do
+    skip 'P_JAILID constant check skipped on this platform' unless bsd
+    expect(Process::P_JAILID).not_to be_nil
   end
 
   def after


### PR DESCRIPTION
This adds the `P_JAILID` constant for BSD platforms.

While I was here I added some documentation for dealing with `Errno::EINTR`, which is typical on most platforms in practice.