### PR TITLE
Add spec helper, refactor tests

### DIFF
--- a/spec/proc_wait3_spec.rb
+++ b/spec/proc_wait3_spec.rb
@@ -1,26 +1,21 @@
 # frozen_string_literal: true
 
-#######################################################################
+##############################################################################
 # proc_wait3_spec.rb
 #
-# Test suite for the Ruby proc-wait3 library. You should run these
-# via the 'rake spec' task.
-#######################################################################
+# Test suite for the Ruby proc-wait3 library. You should run these via the
+# 'rake spec' task.
+#
+# Note that several specs are deliberately wrapped in EINTR rescue handlers
+# because I think the Ruby interpreter is sending a signal to the process
+# from somewhere in the guts of its core code. Originally I thought this was
+# a SIGCHLD but it doesn't always appear to be.
+##############################################################################
 require 'English'
-require 'proc/wait3'
-require 'rspec'
+require 'spec_helper'
 require 'rbconfig'
 
 RSpec.describe Process do
-  # Something in the guts of Ruby was being a pain.
-  Signal.trap('CHLD', 'IGNORE') if RUBY_VERSION.to_f < 3
-
-  let(:solaris) { RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i }
-  let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /darwin|osx/i }
-  let(:hpux)    { RbConfig::CONFIG['host_os'] =~ /hpux/i }
-  let(:linux)   { RbConfig::CONFIG['host_os'] =~ /linux/i }
-  let(:bsd)     { RbConfig::CONFIG['host_os'] =~ /bsd|dragonfly/i }
-
   let(:proc_stat_members) {
     %i[
       pid status utime stime maxrss ixrss idrss isrss minflt majflt nswap
@@ -34,6 +29,24 @@ RSpec.describe Process do
     @pid = nil
   end
 
+  def call_wait3
+    described_class.wait3
+  rescue Errno::EINTR
+    retry
+  end
+
+  def call_wait4(*args)
+    described_class.wait4(*args)
+  rescue Errno::EINTR
+    retry
+  end
+
+  def call_waitid(*args)
+    described_class.waitid(*args)
+  rescue Errno::EINTR
+    retry
+  end
+
   example 'version constant is set to expected value' do
     expect(Process::WAIT3_VERSION).to eq('1.9.2')
     expect(Process::WAIT3_VERSION).to be_frozen
@@ -44,15 +57,13 @@ RSpec.describe Process do
   end
 
   example 'wait3 works as expected' do
-    skip 'wait3 test skipped on this platform' if darwin
     @pid = fork { sleep 0.5 }
-    expect { described_class.wait3 }.not_to raise_error
+    expect { call_wait3 }.not_to raise_error
   end
 
   example 'wait3 returns the expected proc status members' do
-    skip 'wait3 test skipped on this platform' if darwin
     @pid = fork { sleep 0.5 }
-    expect { @proc_stat = described_class.wait3 }.not_to raise_error
+    expect { @proc_stat = call_wait3 }.not_to raise_error
     expect(@proc_stat.members).to eq(proc_stat_members)
   end
 
@@ -62,116 +73,89 @@ RSpec.describe Process do
   end
 
   example 'wait3 sets and returns $last_status to expected values' do
-    skip 'wait3 test skipped on this platform' if darwin
     @pid = fork { sleep 0.5 }
-    described_class.wait3
+    call_wait3
     expect($last_status).to be_a(Struct::ProcStat)
     expect($last_status).not_to be_nil
   end
 
   example 'wait3 sets pid and status members of $?' do
-    skip 'wait3 test skipped on this platform' if darwin
     @pid = fork { sleep 0.5 }
-    described_class.wait3
+    call_wait3
     expect($CHILD_STATUS).not_to be_nil
   end
 
   example 'wait3 returns frozen struct' do
-    skip 'wait3 test skipped on this platform' if darwin
     @pid = fork { sleep 0.5 }
-    struct = described_class.wait3
+    struct = call_wait3
     expect(struct).to be_frozen
   end
 
-  example 'getdtablesize works as expected' do
-    skip 'getdtablesize skipped on this platform' unless solaris
-
+  example 'getdtablesize works as expected', :solaris do
     expect(described_class).to respond_to(:getdtablesize)
     expect(described_class.getdtablesize).to be_a(Integer)
     assert(described_class.getdtablesize > 0)
   end
 
-  example 'wait4 method is defined' do
-    skip 'wait4 test skipped on this platform' if hpux
+  example 'wait4 method is defined', :skip_hpux do
     expect(described_class).to respond_to(:wait4)
   end
 
-  example 'wait4 requires at least one argument' do
-    skip 'wait4 test skipped on this platform' if hpux
-    expect { described_class.wait4 }.to raise_error(ArgumentError)
+  example 'wait4 requires at least one argument', :skip_hpux do
+    expect { call_wait4 }.to raise_error(ArgumentError)
   end
 
-  example 'wait4 works as expected' do
-    skip 'wait4 test skipped on this platform' if hpux || darwin
-
+  example 'wait4 works as expected', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    expect { @proc_stat = described_class.wait4(@pid) }.not_to raise_error
+    expect { @proc_stat = call_wait4(@pid) }.not_to raise_error
     expect(@proc_stat).to be_a(Struct::ProcStat)
   end
 
-  example 'wait4 sets and returns $last_status to expected values' do
-    skip 'wait4 test skipped on this platform' if hpux || darwin
-
+  example 'wait4 sets and returns $last_status to expected values', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    described_class.wait4(@pid)
+    call_wait4(@pid)
     expect($last_status).to be_a(Struct::ProcStat)
     expect($last_status).not_to be_nil
   end
 
-  example 'wait4 sets pid and status members of $?' do
-    skip 'wait4 test skipped on this platform' if hpux || darwin
-
+  example 'wait4 sets pid and status members of $?', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    described_class.wait4(@pid)
+    call_wait4(@pid)
     expect($CHILD_STATUS).not_to be_nil
   end
 
-  example 'wait4 returns frozen struct' do
-    skip 'wait4 test skipped on this platform' if hpux || darwin
-
+  example 'wait4 returns frozen struct', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    struct = described_class.wait4(@pid)
+    struct = call_wait4(@pid)
     expect(struct).to be_frozen
   end
 
-  example 'waitid method is defined' do
-    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
-
+  example 'waitid method is defined', :skip_hpux do
     expect(described_class).to respond_to(:waitid)
   end
 
-  example 'waitid method works as expected' do
-    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
-
+  example 'waitid method works as expected', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    expect { described_class.waitid(Process::P_PID, @pid, Process::WEXITED) }.not_to raise_error
+    expect { call_waitid(Process::P_PID, @pid, Process::WEXITED) }.not_to raise_error
   end
 
-  example 'waitid method raises expected errors if wrong argument type is passed' do
-    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
-
+  example 'waitid method raises expected errors if wrong argument type is passed', :skip_hpux do
     @pid = fork { sleep 0.5 }
-    expect { described_class.waitid('foo', @pid, Process::WEXITED) }.to raise_error(TypeError)
-    expect { described_class.waitid(Process::P_PID, @pid, 'foo') }.to raise_error(TypeError)
-    expect { described_class.waitid(Process::P_PID, 'foo', Process::WEXITED) }.to raise_error(TypeError)
+    expect { call_waitid('foo', @pid, Process::WEXITED) }.to raise_error(TypeError)
+    expect { call_waitid(Process::P_PID, @pid, 'foo') }.to raise_error(TypeError)
+    expect { call_waitid(Process::P_PID, 'foo', Process::WEXITED) }.to raise_error(TypeError)
   end
 
-  example 'waitid method raises expected error if invalid argument is passed' do
-    skip 'waitid test skipped on this platform' if hpux || darwin || bsd
-
+  example 'waitid method raises expected error if invalid argument is passed', :skip_hpux do
     @pid = fork { sleep 0.5 }
     expect { described_class.waitid(Process::P_PID, 99999999, Process::WEXITED) }.to raise_error(Errno::ECHILD)
   end
 
-  example 'sigsend method is defined' do
-    skip 'sigsend test skipped on this platform' unless solaris
-
+  example 'sigsend method is defined', :solaris do
     expect(described_class).to respond_to(:sigsend)
   end
 
-  example 'sigsend works as expected' do
-    skip 'sigsend test skipped on this platform' unless solaris
-
+  example 'sigsend works as expected', :solaris do
     @pid = fork { sleep 0.5 }
     expect { described_class.sigsend(Process::P_PID, @pid, 0) }.not_to raise_error
   end
@@ -187,14 +171,11 @@ RSpec.describe Process do
     expect { described_class.getrusage(true) }.not_to raise_error
   end
 
-  example 'getrusage can get thread info on Linux' do
-    skip 'getrusage only tested on Linux' unless linux
+  example 'getrusage can get thread info on Linux', :linux do
     expect { described_class.getrusage(Process::RUSAGE_THREAD) }.not_to raise_error
   end
 
-  example 'getrusage returns the expected struct' do
-    skip 'getrusage only tested on Linux' unless linux
-
+  example 'getrusage returns the expected struct', :linux do
     @pid = fork { sleep 0.5 }
     expect(described_class.getrusage).to be_a(Struct::RUsage)
     expect(described_class.getrusage.stime).to be_a(Float)
@@ -205,21 +186,18 @@ RSpec.describe Process do
     expect(described_class).to respond_to(:pause)
   end
 
-  example 'expected constants are defined' do
-    skip 'wait constant check skipped on this platform' if darwin || bsd
-
+  example 'expected constants are defined', :skip_darwin, :skip_bsd do
     expect(Process::WCONTINUED).not_to be_nil
     expect(Process::WEXITED).not_to be_nil
     expect(Process::WNOWAIT).not_to be_nil
     expect(Process::WSTOPPED).not_to be_nil
+  end
 
-    skip 'WTRAPPED constant check skipped on this platform' if linux
+  example 'expected constant WTRAPPED is defined', :linux do
     expect(Process::WTRAPPED).not_to be_nil
   end
 
-  example 'expected process type flag constants are defined' do
-    skip 'process type flag check skipped on this platform' if linux || darwin || bsd
-
+  example 'expected process type flag constants are defined', :solaris do
     expect(Process::P_ALL).not_to be_nil
     expect(Process::P_CID).not_to be_nil
     expect(Process::P_GID).not_to be_nil
@@ -227,20 +205,15 @@ RSpec.describe Process do
     expect(Process::P_PID).not_to be_nil
     expect(Process::P_SID).not_to be_nil
     expect(Process::P_UID).not_to be_nil
-
-    skip 'P_MYID constant check skipped on this platform' unless solaris
     expect(Process::P_MYID).not_to be_nil
   end
 
-  example 'solaris-specific process type flags are defined on solaris' do
-    skip 'P_TASKID and P_PROJID constant check skipped on this platform' unless solaris
-
+  example 'solaris-specific process type flags are defined on solaris', :solaris do
     expect(Process::P_TASKID).not_to be_nil
     expect(Process::P_PROJID).not_to be_nil
   end
 
-  example 'bsd-specific process type flags are defined on BSD platforms' do
-    skip 'P_JAILID constant check skipped on this platform' unless bsd
+  example 'bsd-specific process type flags are defined on BSD platforms', :bsd do
     expect(Process::P_JAILID).not_to be_nil
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'proc-wait3'
+
+RSpec.configure do |config|
+  config.filter_run_excluding(:darwin) if Gem::Platform.local.os !~ /darwin|macos/i
+  config.filter_run_excluding(:solaris) if Gem::Platform.local.os !~ /sunos|solaris/i
+  config.filter_run_excluding(:bsd) if Gem::Platform.local.os !~ /bsd|dragonfly/i
+  config.filter_run_excluding(:linux) if Gem::Platform.local.os !~ /linux/i
+
+  config.filter_run_excluding(:skip_hpux) if Gem::Platform.local.os =~ /hpux/i
+  config.filter_run_excluding(:skip_darwin) if Gem::Platform.local.os =~ /darwin|macos/i
+  config.filter_run_excluding(:skip_bsd) if Gem::Platform.local.os =~ /bsd|dragonfly/i
+end


### PR DESCRIPTION
This PR replaces some inline platform checks with a spec helper and tags. I've also refactored the wait3, wait4 and waitid calls to essentially ignore EINTR, so now platforms like Darwin will actually run them.